### PR TITLE
Allow multi-file knowledge uploads with expanded formats

### DIFF
--- a/app/Http/Controllers/AgentKnowledgeController.php
+++ b/app/Http/Controllers/AgentKnowledgeController.php
@@ -19,50 +19,53 @@ class AgentKnowledgeController extends Controller
         $this->ensureOwnership($request, $agent);
 
         $validated = $request->validate([
-            'file' => ['required', 'file', 'mimes:pdf,docx,ppt,pptx', 'max:20480'],
+            'files' => ['required', 'array', 'max:20'],
+            'files.*' => ['file', 'mimes:pdf,doc,docx,odt,ppt,pptx,odp', 'max:20480'],
         ]);
 
-        $uploadedFile = $validated['file'];
-        $uuid = (string) Str::uuid();
-        $workingDir = "tmp/agent-knowledge/{$uuid}";
-        Storage::makeDirectory($workingDir);
+        foreach ($validated['files'] as $uploadedFile) {
+            $uuid = (string) Str::uuid();
+            $workingDir = "tmp/agent-knowledge/{$uuid}";
+            Storage::makeDirectory($workingDir);
 
-        $extension = strtolower($uploadedFile->getClientOriginalExtension() ?: $uploadedFile->extension());
-        $sourceName = 'source.'.$extension;
-        $storedRelativePath = $uploadedFile->storeAs($workingDir, $sourceName);
-        $sourcePath = Storage::path($storedRelativePath);
+            $extension = strtolower($uploadedFile->getClientOriginalExtension() ?: $uploadedFile->extension());
+            $sourceName = 'source.'.$extension;
+            $storedRelativePath = $uploadedFile->storeAs($workingDir, $sourceName);
+            $sourcePath = Storage::path($storedRelativePath);
+            $stream = null;
 
-        try {
-            $pdfPath = $extension === 'pdf'
-                ? $sourcePath
-                : $this->convertToPdf($sourcePath);
+            try {
+                $pdfPath = $extension === 'pdf'
+                    ? $sourcePath
+                    : $this->convertToPdf($sourcePath);
 
-            $stream = fopen($pdfPath, 'r');
+                $stream = fopen($pdfPath, 'r');
 
-            $response = Http::timeout(120)
-                ->attach('file', $stream, basename($pdfPath))
-                ->post(self::UPLOAD_ENDPOINT, [
-                    'UserId' => (string) $request->user()->id,
-                    'AgentId' => (string) $agent->id,
-                ]);
+                $response = Http::timeout(120)
+                    ->attach('file', $stream, basename($pdfPath))
+                    ->post(self::UPLOAD_ENDPOINT, [
+                        'UserId' => (string) $request->user()->id,
+                        'AgentId' => (string) $agent->id,
+                    ]);
 
-            if (is_resource($stream)) {
-                fclose($stream);
+                if ($response->failed()) {
+                    return response()->json([
+                        'message' => 'Unable to upload knowledge base file.',
+                        'details' => $response->json(),
+                    ], $response->status() ?: 500);
+                }
+            } finally {
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
+
+                Storage::deleteDirectory($workingDir);
             }
-
-            if ($response->failed()) {
-                return response()->json([
-                    'message' => 'Unable to upload knowledge base file.',
-                    'details' => $response->json(),
-                ], $response->status() ?: 500);
-            }
-
-            return response()->json([
-                'message' => 'Knowledge uploaded successfully.',
-            ]);
-        } finally {
-            Storage::deleteDirectory($workingDir);
         }
+
+        return response()->json([
+            'message' => 'Knowledge uploaded successfully.',
+        ]);
     }
 
     private function convertToPdf(string $sourcePath): string

--- a/resources/js/dashboard.js
+++ b/resources/js/dashboard.js
@@ -36,8 +36,9 @@ const bubbleClasses = {
 };
 
 const knowledgeMessages = {
-    chooseFile: 'Please choose a file to upload.',
-    invalidFile: 'Only .pdf, .docx, .ppt, or .pptx files are allowed.',
+    chooseFile: 'Please choose at least one file to upload.',
+    invalidFile: 'Only .pdf, .doc, .docx, .odt, .ppt, .pptx, or .odp files are allowed.',
+    fileLimit: 'You can upload up to 20 files at once.',
     modalTitle: 'Add Knowledge',
     modalDescriptionPrefix: 'Upload relevant documents to extend the knowledge base for',
     uploading: 'Uploading...',
@@ -310,27 +311,44 @@ const initAgentKnowledge = () => {
         resetModal();
     };
 
-    const allowedExtensions = ['pdf', 'docx', 'ppt', 'pptx'];
+    const allowedExtensions = ['pdf', 'doc', 'docx', 'odt', 'ppt', 'pptx', 'odp'];
     const allowedMime = [
         'application/pdf',
+        'application/msword',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.oasis.opendocument.text',
         'application/vnd.ms-powerpoint',
         'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'application/vnd.oasis.opendocument.presentation',
     ];
 
-    const validateFile = (file) => {
-        if (!file) {
+    const validateFiles = (files) => {
+        if (!files || files.length === 0) {
             errorEl.textContent = knowledgeMessages.chooseFile;
             errorEl.classList.remove('hidden');
             return false;
         }
 
-        const ext = file.name.split('.').pop()?.toLowerCase();
-        const mimeAllowed = allowedMime.includes(file.type) || file.type === '';
-        if (!allowedExtensions.includes(ext) || (!mimeAllowed && ext === 'pdf')) {
-            errorEl.textContent = knowledgeMessages.invalidFile;
+        if (files.length > 20) {
+            errorEl.textContent = knowledgeMessages.fileLimit;
             errorEl.classList.remove('hidden');
             return false;
+        }
+
+        for (const file of files) {
+            const ext = file.name.split('.').pop()?.toLowerCase();
+
+            if (!ext || !allowedExtensions.includes(ext)) {
+                errorEl.textContent = knowledgeMessages.invalidFile;
+                errorEl.classList.remove('hidden');
+                return false;
+            }
+
+            if (file.type && !allowedMime.includes(file.type)) {
+                errorEl.textContent = knowledgeMessages.invalidFile;
+                errorEl.classList.remove('hidden');
+                return false;
+            }
         }
 
         errorEl.classList.add('hidden');
@@ -358,14 +376,16 @@ const initAgentKnowledge = () => {
 
     const submitKnowledge = async (event) => {
         event.preventDefault();
-        const file = fileInput.files?.[0] ?? null;
+        const files = Array.from(fileInput.files ?? []);
 
-        if (!validateFile(file) || !endpoint) {
+        if (!validateFiles(files) || !endpoint) {
             return;
         }
 
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach((file) => {
+            formData.append('files[]', file);
+        });
 
         const originalLabel = submitBtn.textContent;
         submitBtn.disabled = true;

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -193,8 +193,8 @@
                 @csrf
                 <div>
                     <label for="agent-knowledge-file" class="block text-xs font-semibold text-gray-600 uppercase tracking-wide">{{ __('Knowledge File') }}</label>
-                    <input id="agent-knowledge-file" name="file" type="file" accept=".pdf,.docx,.ppt,.pptx" class="mt-1 block w-full text-sm text-gray-700 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" required>
-                    <p class="mt-1 text-xs text-gray-500">{{ __('Accepted formats: .pdf, .docx, .ppt, .pptx (max 20 MB).') }}</p>
+                    <input id="agent-knowledge-file" name="files[]" type="file" accept=".pdf,.doc,.docx,.odt,.ppt,.pptx,.odp" class="mt-1 block w-full text-sm text-gray-700 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" multiple required>
+                    <p class="mt-1 text-xs text-gray-500">{{ __('Accepted formats: .pdf, .doc, .docx, .odt, .ppt, .pptx, .odp (max 20 MB per file, up to 20 files).') }}</p>
                     <p class="mt-2 text-xs text-red-600 hidden" id="agent-knowledge-error"></p>
                 </div>
                 <div class="text-sm text-gray-600" id="agent-knowledge-status"></div>


### PR DESCRIPTION
## Summary
- allow uploading up to 20 knowledge files and process each upload on the server
- enable multi-file selection in the knowledge modal with updated validation and messaging
- expand accepted formats to include doc, odt, and odp variants for knowledge uploads

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d24dc54b508325a8cffc565e2632fb