### PR TITLE
Ensure multi-file knowledge uploads preserve numbered filenames

### DIFF
--- a/app/Http/Controllers/AgentKnowledgeController.php
+++ b/app/Http/Controllers/AgentKnowledgeController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers;
 use App\Models\Agent;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
@@ -18,54 +20,144 @@ class AgentKnowledgeController extends Controller
     {
         $this->ensureOwnership($request, $agent);
 
-        $validated = $request->validate([
-            'file' => ['required', 'file', 'mimes:pdf,docx,ppt,pptx', 'max:20480'],
-        ]);
+        $files = $this->gatherUploadedFiles($request);
+        $shouldNumberFiles = count($files) > 1;
 
-        $uploadedFile = $validated['file'];
-        $uuid = (string) Str::uuid();
-        $workingDir = "tmp/agent-knowledge/{$uuid}";
-        Storage::makeDirectory($workingDir);
+        $validated = Validator::make([
+            'files' => $files,
+        ], [
+            'files' => ['required', 'array', 'min:1', 'max:20'],
+            'files.*' => ['file', 'mimes:pdf,doc,docx,odt,ppt,pptx,odp', 'max:20480'],
+        ])->validate();
 
-        $extension = strtolower($uploadedFile->getClientOriginalExtension() ?: $uploadedFile->extension());
-        $sourceName = 'source.'.$extension;
-        $storedRelativePath = $uploadedFile->storeAs($workingDir, $sourceName);
-        $sourcePath = Storage::path($storedRelativePath);
+        $normalizedFiles = array_values($validated['files']);
 
-        try {
-            $pdfPath = $extension === 'pdf'
-                ? $sourcePath
-                : $this->convertToPdf($sourcePath);
+        foreach ($normalizedFiles as $index => $uploadedFile) {
+            $uuid = (string) Str::uuid();
+            $workingDir = "tmp/agent-knowledge/{$uuid}";
+            Storage::makeDirectory($workingDir);
 
-            $stream = fopen($pdfPath, 'r');
+            $extension = strtolower($uploadedFile->getClientOriginalExtension() ?: $uploadedFile->extension());
+            $baseName = $shouldNumberFiles
+                ? 'source'.($index + 1)
+                : 'source';
+            $sourceName = $baseName.'.'.$extension;
+            $storedRelativePath = $uploadedFile->storeAs($workingDir, $sourceName);
+            $sourcePath = Storage::path($storedRelativePath);
+            $finalPdfName = $baseName.'.pdf';
+            $finalPdfPath = dirname($sourcePath).DIRECTORY_SEPARATOR.$finalPdfName;
 
-            $response = Http::timeout(120)
-                ->attach('file', $stream, basename($pdfPath))
-                ->post(self::UPLOAD_ENDPOINT, [
-                    'UserId' => (string) $request->user()->id,
-                    'AgentId' => (string) $agent->id,
-                ]);
+            try {
+                $pdfPath = $extension === 'pdf'
+                    ? $this->ensurePdfName($sourcePath, $finalPdfPath)
+                    : $this->convertToPdf($sourcePath, $finalPdfPath);
 
-            if (is_resource($stream)) {
-                fclose($stream);
+                $stream = fopen($pdfPath, 'r');
+
+                if ($stream === false) {
+                    throw new \RuntimeException('Unable to open the PDF file for uploading.');
+                }
+
+                try {
+                    $response = Http::timeout(120)
+                        ->attach('file', $stream, $finalPdfName)
+                        ->post(self::UPLOAD_ENDPOINT, [
+                            'UserId' => (string) $request->user()->id,
+                            'AgentId' => (string) $agent->id,
+                        ]);
+                } finally {
+                    if (is_resource($stream)) {
+                        fclose($stream);
+                    }
+                }
+
+                if ($response->failed()) {
+                    return response()->json([
+                        'message' => 'Unable to upload knowledge base file.',
+                        'details' => $response->json(),
+                    ], $response->status() ?: 500);
+                }
+            } finally {
+                Storage::deleteDirectory($workingDir);
             }
-
-            if ($response->failed()) {
-                return response()->json([
-                    'message' => 'Unable to upload knowledge base file.',
-                    'details' => $response->json(),
-                ], $response->status() ?: 500);
-            }
-
-            return response()->json([
-                'message' => 'Knowledge uploaded successfully.',
-            ]);
-        } finally {
-            Storage::deleteDirectory($workingDir);
         }
+
+        return response()->json([
+            'message' => 'Knowledge uploaded successfully.',
+        ]);
     }
 
-    private function convertToPdf(string $sourcePath): string
+    /**
+     * @param  array<int|string, UploadedFile|array|null>|UploadedFile|null  $files
+     * @return array<int, UploadedFile>
+     */
+    private function normalizeUploadedFiles(null|UploadedFile|array $files): array
+    {
+        if ($files === null) {
+            return [];
+        }
+
+        if ($files instanceof UploadedFile) {
+            return [$files];
+        }
+
+        $normalized = [];
+
+        foreach ($files as $file) {
+            if ($file instanceof UploadedFile) {
+                $normalized[] = $file;
+                continue;
+            }
+
+            if (is_array($file)) {
+                $normalized = array_merge($normalized, $this->normalizeUploadedFiles($file));
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    private function gatherUploadedFiles(Request $request): array
+    {
+        $candidates = [
+            $request->file('files'),
+            $request->file('file'),
+            data_get($request->allFiles(), 'files'),
+        ];
+
+        $collected = [];
+        $seen = [];
+
+        foreach ($candidates as $candidate) {
+            foreach ($this->normalizeUploadedFiles($candidate) as $file) {
+                $hash = spl_object_hash($file);
+
+                if (isset($seen[$hash])) {
+                    continue;
+                }
+
+                $seen[$hash] = true;
+                $collected[] = $file;
+            }
+        }
+
+        return $collected;
+    }
+
+    private function ensurePdfName(string $sourcePath, string $desiredPdfPath): string
+    {
+        if (basename($sourcePath) === basename($desiredPdfPath)) {
+            return $sourcePath;
+        }
+
+        if (! rename($sourcePath, $desiredPdfPath)) {
+            throw new \RuntimeException('Unable to rename the uploaded PDF file.');
+        }
+
+        return $desiredPdfPath;
+    }
+
+    private function convertToPdf(string $sourcePath, string $desiredPdfPath): string
     {
         $outputDir = dirname($sourcePath);
         $binary = $this->resolveLibreOfficeBinary();
@@ -100,7 +192,12 @@ class AgentKnowledgeController extends Controller
             throw new \RuntimeException('Converted PDF file could not be located.');
         }
 
-        return $pdfPath;
+        if (basename($pdfPath) !== basename($desiredPdfPath) && ! rename($pdfPath, $desiredPdfPath)) {
+            throw new \RuntimeException('Unable to rename the converted PDF file.');
+        }
+
+        return $desiredPdfPath;
+
     }
 
     private function resolveLibreOfficeBinary(): string

--- a/resources/js/dashboard.js
+++ b/resources/js/dashboard.js
@@ -36,8 +36,9 @@ const bubbleClasses = {
 };
 
 const knowledgeMessages = {
-    chooseFile: 'Please choose a file to upload.',
-    invalidFile: 'Only .pdf, .docx, .ppt, or .pptx files are allowed.',
+    chooseFile: 'Please choose at least one file to upload.',
+    invalidFile: 'Only .pdf, .doc, .docx, .odt, .ppt, .pptx, or .odp files are allowed.',
+    fileLimit: 'You can upload up to 20 files at once.',
     modalTitle: 'Add Knowledge',
     modalDescriptionPrefix: 'Upload relevant documents to extend the knowledge base for',
     uploading: 'Uploading...',
@@ -310,27 +311,44 @@ const initAgentKnowledge = () => {
         resetModal();
     };
 
-    const allowedExtensions = ['pdf', 'docx', 'ppt', 'pptx'];
+    const allowedExtensions = ['pdf', 'doc', 'docx', 'odt', 'ppt', 'pptx', 'odp'];
     const allowedMime = [
         'application/pdf',
+        'application/msword',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.oasis.opendocument.text',
         'application/vnd.ms-powerpoint',
         'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'application/vnd.oasis.opendocument.presentation',
     ];
 
-    const validateFile = (file) => {
-        if (!file) {
+    const validateFiles = (files) => {
+        if (!files || files.length === 0) {
             errorEl.textContent = knowledgeMessages.chooseFile;
             errorEl.classList.remove('hidden');
             return false;
         }
 
-        const ext = file.name.split('.').pop()?.toLowerCase();
-        const mimeAllowed = allowedMime.includes(file.type) || file.type === '';
-        if (!allowedExtensions.includes(ext) || (!mimeAllowed && ext === 'pdf')) {
-            errorEl.textContent = knowledgeMessages.invalidFile;
+        if (files.length > 20) {
+            errorEl.textContent = knowledgeMessages.fileLimit;
             errorEl.classList.remove('hidden');
             return false;
+        }
+
+        for (const file of files) {
+            const ext = file.name.split('.').pop()?.toLowerCase();
+
+            if (!ext || !allowedExtensions.includes(ext)) {
+                errorEl.textContent = knowledgeMessages.invalidFile;
+                errorEl.classList.remove('hidden');
+                return false;
+            }
+
+            if (file.type && !allowedMime.includes(file.type)) {
+                errorEl.textContent = knowledgeMessages.invalidFile;
+                errorEl.classList.remove('hidden');
+                return false;
+            }
         }
 
         errorEl.classList.add('hidden');
@@ -358,14 +376,16 @@ const initAgentKnowledge = () => {
 
     const submitKnowledge = async (event) => {
         event.preventDefault();
-        const file = fileInput.files?.[0] ?? null;
+        const files = Array.from(fileInput.files ?? []);
 
-        if (!validateFile(file) || !endpoint) {
+        if (!validateFiles(files) || !endpoint) {
             return;
         }
 
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach((file) => {
+            formData.append('files[]', file);
+        });
 
         const originalLabel = submitBtn.textContent;
         submitBtn.disabled = true;

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -193,8 +193,8 @@
                 @csrf
                 <div>
                     <label for="agent-knowledge-file" class="block text-xs font-semibold text-gray-600 uppercase tracking-wide">{{ __('Knowledge File') }}</label>
-                    <input id="agent-knowledge-file" name="file" type="file" accept=".pdf,.docx,.ppt,.pptx" class="mt-1 block w-full text-sm text-gray-700 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" required>
-                    <p class="mt-1 text-xs text-gray-500">{{ __('Accepted formats: .pdf, .docx, .ppt, .pptx (max 20 MB).') }}</p>
+                    <input id="agent-knowledge-file" name="files[]" type="file" accept=".pdf,.doc,.docx,.odt,.ppt,.pptx,.odp" class="mt-1 block w-full text-sm text-gray-700 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" multiple required>
+                    <p class="mt-1 text-xs text-gray-500">{{ __('Accepted formats: .pdf, .doc, .docx, .odt, .ppt, .pptx, .odp (max 20 MB per file, up to 20 files).') }}</p>
                     <p class="mt-2 text-xs text-red-600 hidden" id="agent-knowledge-error"></p>
                 </div>
                 <div class="text-sm text-gray-600" id="agent-knowledge-status"></div>


### PR DESCRIPTION
## Summary
- normalise validated uploads to keep every selected document in the processing loop before dispatching to the webhook
- base numbered filenames on the collected upload count and reuse the working files when converting so multi-file submissions retain their source{n}.pdf pattern
- stream each upload to the webhook through file handles and close them afterward so every document is delivered separately with its numbered name

## Testing
- php artisan test *(fails: vendor/autoload.php missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d24dc54b508325a8cffc565e2632fb