### PR TITLE
Ensure knowledge uploads use original filenames

### DIFF
--- a/app/Http/Controllers/AgentKnowledgeController.php
+++ b/app/Http/Controllers/AgentKnowledgeController.php
@@ -23,73 +23,116 @@ class AgentKnowledgeController extends Controller
 
         $files = $this->validatedUploads($request);
 
+        $preparedFiles = [];
+
         foreach ($files as $uploadedFile) {
             $uuid = (string) Str::uuid();
             $workingDir = "tmp/agent-knowledge/{$uuid}";
             Storage::makeDirectory($workingDir);
 
-            $extension = strtolower($uploadedFile->getClientOriginalExtension() ?: $uploadedFile->extension());
-            $originalClientName = trim($uploadedFile->getClientOriginalName());
-            $originalBaseName = pathinfo($originalClientName, PATHINFO_FILENAME) ?: 'document';
-            $normalizedBaseName = Str::slug($originalBaseName) ?: 'document';
-
-            $sourceName = $normalizedBaseName.'.'.$extension;
-            $storedRelativePath = $uploadedFile->storeAs($workingDir, $sourceName);
-            $sourcePath = Storage::path($storedRelativePath);
-            $stream = null;
-
             try {
+                $extension = strtolower($uploadedFile->getClientOriginalExtension() ?: $uploadedFile->extension());
+                $originalClientName = trim($uploadedFile->getClientOriginalName());
+                $originalBaseName = pathinfo($originalClientName, PATHINFO_FILENAME) ?: 'document';
+                $normalizedBaseName = Str::slug($originalBaseName) ?: 'document';
+
+                $sourceName = $normalizedBaseName.'.'.$extension;
+                $storedRelativePath = $uploadedFile->storeAs($workingDir, $sourceName);
+                $sourcePath = Storage::path($storedRelativePath);
+
                 $pdfPath = $extension === 'pdf'
                     ? $sourcePath
                     : $this->convertToPdf($sourcePath);
-
-                $stream = fopen($pdfPath, 'r');
 
                 $uploadFilename = $extension === 'pdf'
                     ? ($originalClientName !== '' ? $originalClientName : $sourceName)
                     : ($originalBaseName !== '' ? $originalBaseName.'.pdf' : 'document.pdf');
 
-                Log::info('Uploading knowledge file to n8n.', [
-                    'agent_id' => $agent->id,
-                    'user_id' => $request->user()->id,
-                    'original_filename' => $originalClientName ?: $uploadedFile->getClientOriginalName(),
+                $preparedFiles[] = [
+                    'original_filename' => $originalClientName !== '' ? $originalClientName : $uploadedFile->getClientOriginalName(),
                     'sent_filename' => $uploadFilename,
-                ]);
+                    'pdf_path' => $pdfPath,
+                    'working_dir' => $workingDir,
+                ];
+            } catch (\Throwable $exception) {
+                Storage::deleteDirectory($workingDir);
 
-                $response = Http::timeout(120)
-                    ->attach('file', $stream, $uploadFilename)
-                    ->post(self::UPLOAD_ENDPOINT, [
-                        'UserId' => (string) $request->user()->id,
-                        'AgentId' => (string) $agent->id,
-                    ]);
+                throw $exception;
+            }
+        }
 
-                if ($response->failed()) {
-                    Log::warning('Knowledge upload failed.', [
-                        'agent_id' => $agent->id,
-                        'user_id' => $request->user()->id,
-                        'sent_filename' => $uploadFilename,
-                        'status' => $response->status(),
-                        'response_body' => $response->body(),
-                    ]);
+        $streams = [];
 
-                    return response()->json([
-                        'message' => 'Unable to upload knowledge base file.',
-                        'details' => $response->json(),
-                    ], $response->status() ?: 500);
+        try {
+            $pendingRequest = Http::timeout(120);
+
+            foreach ($preparedFiles as $fileMeta) {
+                $stream = fopen($fileMeta['pdf_path'], 'r');
+
+                if ($stream === false) {
+                    throw new \RuntimeException(sprintf('Unable to open file stream for %s.', $fileMeta['pdf_path']));
                 }
 
-                Log::info('Knowledge upload succeeded.', [
+                $streams[] = $stream;
+
+                $pendingRequest = $pendingRequest->attach(
+                    'files[]',
+                    $stream,
+                    $fileMeta['sent_filename']
+                );
+            }
+
+            $filesPayload = array_map(static function (array $fileMeta): array {
+                return [
+                    'original_filename' => $fileMeta['original_filename'],
+                    'sent_filename' => $fileMeta['sent_filename'],
+                ];
+            }, $preparedFiles);
+
+            Log::info('Uploading knowledge files to n8n.', [
+                'agent_id' => $agent->id,
+                'user_id' => $request->user()->id,
+                'file_count' => count($filesPayload),
+                'files' => $filesPayload,
+            ]);
+
+            $response = $pendingRequest->post(self::UPLOAD_ENDPOINT, [
+                'UserId' => (string) $request->user()->id,
+                'AgentId' => (string) $agent->id,
+            ]);
+
+            if ($response->failed()) {
+                Log::warning('Knowledge upload failed.', [
                     'agent_id' => $agent->id,
                     'user_id' => $request->user()->id,
-                    'sent_filename' => $uploadFilename,
+                    'file_count' => count($filesPayload),
+                    'files' => $filesPayload,
                     'status' => $response->status(),
+                    'response_body' => $response->body(),
                 ]);
-            } finally {
+
+                return response()->json([
+                    'message' => 'Unable to upload knowledge base file.',
+                    'details' => $response->json(),
+                ], $response->status() ?: 500);
+            }
+
+            Log::info('Knowledge upload succeeded.', [
+                'agent_id' => $agent->id,
+                'user_id' => $request->user()->id,
+                'file_count' => count($filesPayload),
+                'files' => $filesPayload,
+                'status' => $response->status(),
+            ]);
+        } finally {
+            foreach ($streams as $stream) {
                 if (is_resource($stream)) {
                     fclose($stream);
                 }
+            }
 
-                Storage::deleteDirectory($workingDir);
+            foreach ($preparedFiles as $fileMeta) {
+                Storage::deleteDirectory($fileMeta['working_dir']);
             }
         }
 

--- a/app/Http/Controllers/AgentKnowledgeController.php
+++ b/app/Http/Controllers/AgentKnowledgeController.php
@@ -66,7 +66,7 @@ class AgentKnowledgeController extends Controller
         try {
             $pendingRequest = Http::timeout(120);
 
-            foreach ($preparedFiles as $fileMeta) {
+            foreach ($preparedFiles as $index => $fileMeta) {
                 $stream = fopen($fileMeta['pdf_path'], 'r');
 
                 if ($stream === false) {
@@ -76,7 +76,7 @@ class AgentKnowledgeController extends Controller
                 $streams[] = $stream;
 
                 $pendingRequest = $pendingRequest->attach(
-                    'files[]',
+                    sprintf('files[%d]', $index),
                     $stream,
                     $fileMeta['sent_filename']
                 );

--- a/app/Http/Controllers/AgentKnowledgeController.php
+++ b/app/Http/Controllers/AgentKnowledgeController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Agent;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -19,12 +21,9 @@ class AgentKnowledgeController extends Controller
     {
         $this->ensureOwnership($request, $agent);
 
-        $validated = $request->validate([
-            'files' => ['required', 'array', 'max:20'],
-            'files.*' => ['file', 'mimes:pdf,doc,docx,odt,ppt,pptx,odp', 'max:20480'],
-        ]);
+        $files = $this->validatedUploads($request);
 
-        foreach ($validated['files'] as $uploadedFile) {
+        foreach ($files as $uploadedFile) {
             $uuid = (string) Str::uuid();
             $workingDir = "tmp/agent-knowledge/{$uuid}";
             Storage::makeDirectory($workingDir);
@@ -97,6 +96,59 @@ class AgentKnowledgeController extends Controller
         return response()->json([
             'message' => 'Knowledge uploaded successfully.',
         ]);
+    }
+
+    /**
+     * @return UploadedFile[]
+     */
+    private function validatedUploads(Request $request): array
+    {
+        $files = $this->normalizeUploadedFiles($request);
+
+        return validator(
+            ['files' => $files],
+            [
+                'files' => ['required', 'array', 'max:20'],
+                'files.*' => ['file', 'mimes:pdf,doc,docx,odt,ppt,pptx,odp', 'max:20480'],
+            ]
+        )->validate()['files'];
+    }
+
+    /**
+     * @return UploadedFile[]
+     */
+    private function normalizeUploadedFiles(Request $request): array
+    {
+        $allFiles = $request->allFiles();
+        $files = $allFiles['files'] ?? null;
+
+        if ($files === null) {
+            $files = $request->file('file');
+        }
+
+        return $this->flattenFiles($files);
+    }
+
+    /**
+     * @param  array<int|string, mixed>|UploadedFile|null  $files
+     * @return UploadedFile[]
+     */
+    private function flattenFiles($files): array
+    {
+        $normalized = [];
+
+        foreach (Arr::wrap($files) as $file) {
+            if ($file instanceof UploadedFile) {
+                $normalized[] = $file;
+                continue;
+            }
+
+            if (is_array($file)) {
+                $normalized = array_merge($normalized, $this->flattenFiles($file));
+            }
+        }
+
+        return $normalized;
     }
 
     private function convertToPdf(string $sourcePath): string

--- a/app/Http/Controllers/AgentKnowledgeController.php
+++ b/app/Http/Controllers/AgentKnowledgeController.php
@@ -6,6 +6,7 @@ use App\Models\Agent;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
@@ -29,7 +30,11 @@ class AgentKnowledgeController extends Controller
             Storage::makeDirectory($workingDir);
 
             $extension = strtolower($uploadedFile->getClientOriginalExtension() ?: $uploadedFile->extension());
-            $sourceName = 'source.'.$extension;
+            $originalClientName = trim($uploadedFile->getClientOriginalName());
+            $originalBaseName = pathinfo($originalClientName, PATHINFO_FILENAME) ?: 'document';
+            $normalizedBaseName = Str::slug($originalBaseName) ?: 'document';
+
+            $sourceName = $normalizedBaseName.'.'.$extension;
             $storedRelativePath = $uploadedFile->storeAs($workingDir, $sourceName);
             $sourcePath = Storage::path($storedRelativePath);
             $stream = null;
@@ -41,19 +46,45 @@ class AgentKnowledgeController extends Controller
 
                 $stream = fopen($pdfPath, 'r');
 
+                $uploadFilename = $extension === 'pdf'
+                    ? ($originalClientName !== '' ? $originalClientName : $sourceName)
+                    : ($originalBaseName !== '' ? $originalBaseName.'.pdf' : 'document.pdf');
+
+                Log::info('Uploading knowledge file to n8n.', [
+                    'agent_id' => $agent->id,
+                    'user_id' => $request->user()->id,
+                    'original_filename' => $originalClientName ?: $uploadedFile->getClientOriginalName(),
+                    'sent_filename' => $uploadFilename,
+                ]);
+
                 $response = Http::timeout(120)
-                    ->attach('file', $stream, basename($pdfPath))
+                    ->attach('file', $stream, $uploadFilename)
                     ->post(self::UPLOAD_ENDPOINT, [
                         'UserId' => (string) $request->user()->id,
                         'AgentId' => (string) $agent->id,
                     ]);
 
                 if ($response->failed()) {
+                    Log::warning('Knowledge upload failed.', [
+                        'agent_id' => $agent->id,
+                        'user_id' => $request->user()->id,
+                        'sent_filename' => $uploadFilename,
+                        'status' => $response->status(),
+                        'response_body' => $response->body(),
+                    ]);
+
                     return response()->json([
                         'message' => 'Unable to upload knowledge base file.',
                         'details' => $response->json(),
                     ], $response->status() ?: 500);
                 }
+
+                Log::info('Knowledge upload succeeded.', [
+                    'agent_id' => $agent->id,
+                    'user_id' => $request->user()->id,
+                    'sent_filename' => $uploadFilename,
+                    'status' => $response->status(),
+                ]);
             } finally {
                 if (is_resource($stream)) {
                     fclose($stream);


### PR DESCRIPTION
## Summary
- preserve each uploaded document's original name when storing, converting to PDF, and forwarding to the n8n webhook so multiple files are delivered distinctly
- add info/warning logs around each webhook request to trace filenames and responses

## Testing
- php artisan test *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d39a924cf483258a7a03bbc719b75b